### PR TITLE
Adapt to standard-library 1.5 (trivial fix)

### DIFF
--- a/generic.agda-lib
+++ b/generic.agda-lib
@@ -1,3 +1,3 @@
-name: generic-0.1
+name: generic-0.1.0.2
 depend: standard-library
 include: src

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 It's a library for doing generic programming in Agda.
 
-The library is tested with Agda-2.6.1 and likely does not work with other versions of Agda.
+The library is tested with Agda-2.6.1 and Agda-2.6.1.2 and likely does not work with other versions of Agda.
 
 # A quick taste
 

--- a/src/Generic/Lib/Data/Sum.agda
+++ b/src/Generic/Lib/Data/Sum.agda
@@ -1,3 +1,3 @@
 module Generic.Lib.Data.Sum where
 
-open import Data.Sum hiding (swap) renaming (map to smap) hiding (map₁; map₂; assocʳ; assocˡ) public
+open import Data.Sum hiding (swap) renaming (map to smap) hiding (map₁; map₂; assocʳ; assocˡ; reduce) public


### PR DESCRIPTION
This pull request adapts Generic to the newly-released standard-library 1.5.

The fix needed was extremely minimal.

For your convenience, I also bumped the version in `generic.agda-lib` to 0.1.0.2. If you like this pull request, then you would just have to merge it and tag it as v0.1.0.2, then the Nix crowd could update your library in the Nix package store. :-)